### PR TITLE
Split up module before packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# concierge-cli
-Concierge repository projects management CLI.

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,65 @@
+Concierge-cli |latest-version|
+==============================
+
+|build-status| |python-support| |license|
+
+Companion CLI for `Concierge`_, the Configuration management & CI solution
+for aligning your multitude of Git repositories.  Allows you to bulk-manage
+properties of your Git repository projects.  Currently, GitLab is supported.
+
+.. |latest-version| image:: https://img.shields.io/pypi/v/concierge-cli.svg
+   :alt: Latest version on PyPI
+   :target: https://pypi.org/project/concierge-cli
+.. |build-status| image:: https://img.shields.io/travis/vshn/concierge-cli/master.svg
+   :alt: Build status
+   :target: https://travis-ci.org/vshn/concierge-cli
+.. |python-support| image:: https://img.shields.io/pypi/pyversions/concierge-cli.svg
+   :alt: Python versions
+   :target: https://pypi.org/project/concierge-cli
+.. |license| image:: https://img.shields.io/pypi/l/concierge-cli.svg
+   :alt: Software license
+   :target: https://github.com/vshn/concierge-cli/blob/master/LICENSE
+
+.. _Concierge: https://hub.docker.com/r/vshn/concierge/
+
+Why I Should I Use This Tool?
+-----------------------------
+
+Concierge-cli helps you analyze and bulk-update the repository projects you
+manage (e.g. set topics on projects, generate project lists for ModuleSync).
+
+Installation
+------------
+
+From PyPI:
+
+.. code-block:: console
+
+    $ pip install concierge-cli
+
+Usage Patterns
+--------------
+
+List all projects (for a private GitLab) that have no topics yet:
+
+.. code-block:: console
+
+    $ concierge-cli gitlab --uri git.vs.hn topics --empty
+
+List all projects "foo" or similar in group "bar" or similar: (on GitLab.com)
+
+.. code-block:: console
+
+    $ concierge-cli gitlab topics bar/foo --empty
+
+Set topics on all those projects:
+
+.. code-block:: console
+
+    $ concierge-cli gitlab topics bar/foo --empty --set-topic Puppet --set-topic Ansible
+
+List all projects *with* topics now: (double-check)
+
+.. code-block:: console
+
+    $ concierge-cli gitlab topics bar/foo

--- a/concierge_cli/__init__.py
+++ b/concierge_cli/__init__.py
@@ -1,0 +1,8 @@
+"""
+Concierge repository projects management CLI.
+"""
+__author__ = 'VSHN AG'
+__email__ = 'tech@vshn.ch'
+__url__ = 'https://github.com/vshn/concierge-cli'
+__version__ = '0.1.0.dev1'
+__license__ = 'BSD 3-Clause'

--- a/concierge_cli/adapter.py
+++ b/concierge_cli/adapter.py
@@ -1,0 +1,38 @@
+"""
+Concierge repository projects management CLI.
+"""
+
+
+class Project:
+    """
+    Adapter wrapping a project from a repository service API
+    """
+
+    def __init__(self, api, project):
+        """A GitLab API project, currently."""
+        self.group_project = project
+        self.name = project.attributes['path_with_namespace']
+        self.topic_list = project.attributes['tag_list']
+        self.topic_count = len(self.topic_list)
+        self.api = api
+
+    def show_topics(self):
+        """Display the project name and project topics"""
+        if self.topic_count:
+            print(f"{self.topic_count} topics in {self.name}: "
+                  f"{str(self.topic_list)[1:-1]}")
+        else:
+            print(f"{self.name}")
+
+    def set_topics(self, new_topics):
+        """Update the project topics"""
+        if self.topic_count:
+            print(f"Replacing topics on {self.name}: "
+                  f"{self.topic_list} -> {new_topics}")
+        else:
+            print(f"Setting new topics on {self.name}: {new_topics}")
+
+        # get a full-featured project (a group project has limited features)
+        project = self.api.projects.get(self.group_project.id, lazy=True)
+        project.tag_list = new_topics
+        project.save()

--- a/concierge_cli/cli.py
+++ b/concierge_cli/cli.py
@@ -1,101 +1,12 @@
 """
-Concierge repository projects management CLI.
+CLI implementation for Concierge.
 """
 import click
 
-from gitlab import Gitlab
-from gitlab.config import GitlabConfigMissingError
 from gitlab.exceptions import GitlabError
 from requests.exceptions import RequestException
 
-DEFAULT_GITLAB_URI = 'https://gitlab.com'
-MAX_GROUPS = 999_999
-
-
-class Project:
-    """
-    Adapter wrapping a project from a repository service API
-    """
-
-    def __init__(self, api, project):
-        """A GitLab API project, currently."""
-        self.group_project = project
-        self.name = project.attributes['path_with_namespace']
-        self.topic_list = project.attributes['tag_list']
-        self.topic_count = len(self.topic_list)
-        self.api = api
-
-    def show_topics(self):
-        """Display the project name and project topics"""
-        if self.topic_count:
-            print(f"{self.topic_count} topics in {self.name}: "
-                  f"{str(self.topic_list)[1:-1]}")
-        else:
-            print(f"{self.name}")
-
-    def set_topics(self, new_topics):
-        """Update the project topics"""
-        if self.topic_count:
-            print(f"Replacing topics on {self.name}: "
-                  f"{self.topic_list} -> {new_topics}")
-        else:
-            print(f"Setting new topics on {self.name}: {new_topics}")
-
-        # get a full-featured project (a group project has limited features)
-        project = self.api.projects.get(self.group_project.id, lazy=True)
-        project.tag_list = new_topics
-        project.save()
-
-
-class TopicManager:
-    """
-    Manages topics on GitLab projects (visible in project settings).
-    """
-
-    def __init__(self, group_filter, project_filter, empty,
-                 uri=None, token=None):
-        """
-        Connects to a GitLab instance using connection details from one of the
-        local configuration files (see https://python-gitlab.readthedocs.io >
-        Configuration > Files). Connects to GitLab.com by default if no config
-        file is found. Specify an URI to override the config file lookup, the
-        token is optional (anonymous access if none is supplied).
-        """
-        self.group_filter = group_filter
-        self.project_filter = project_filter
-        self.empty = empty
-
-        if not uri:
-            try:
-                self.api = Gitlab.from_config()
-            except GitlabConfigMissingError:
-                uri = DEFAULT_GITLAB_URI
-
-        if uri:
-            self.api = Gitlab(uri, private_token=token)
-
-    def projects(self):
-        """
-        List all projects and their topics, filtered by an optional
-        search pattern.
-        """
-        for group in self.api.groups.list(search=self.group_filter,
-                                          per_page=MAX_GROUPS):
-            for project in group.projects.list(search=self.project_filter):
-                project = Project(self.api, project)
-                if (self.empty and not project.topic_count) or \
-                        (not self.empty and project.topic_count):
-                    yield project
-
-    def show(self):
-        """Display all found projects and their topics."""
-        for project in self.projects():
-            project.show_topics()
-
-    def set(self, new_topics):
-        """Set a list of topics on the projects found."""
-        for project in self.projects():
-            project.set_topics(new_topics)
+from .manager import DEFAULT_GITLAB_URI, TopicManager
 
 
 @click.group()

--- a/concierge_cli/manager.py
+++ b/concierge_cli/manager.py
@@ -1,0 +1,61 @@
+"""
+Concierge repository projects management CLI.
+"""
+from gitlab import Gitlab
+from gitlab.config import GitlabConfigMissingError
+
+from .adapter import Project
+
+DEFAULT_GITLAB_URI = 'https://gitlab.com'
+MAX_GROUPS = 999_999
+
+
+class TopicManager:
+    """
+    Manages topics on GitLab projects (visible in project settings).
+    """
+
+    def __init__(self, group_filter, project_filter, empty,
+                 uri=None, token=None):
+        """
+        Connects to a GitLab instance using connection details from one of the
+        local configuration files (see https://python-gitlab.readthedocs.io >
+        Configuration > Files). Connects to GitLab.com by default if no config
+        file is found. Specify an URI to override the config file lookup, the
+        token is optional (anonymous access if none is supplied).
+        """
+        self.group_filter = group_filter
+        self.project_filter = project_filter
+        self.empty = empty
+
+        if not uri:
+            try:
+                self.api = Gitlab.from_config()
+            except GitlabConfigMissingError:
+                uri = DEFAULT_GITLAB_URI
+
+        if uri:
+            self.api = Gitlab(uri, private_token=token)
+
+    def projects(self):
+        """
+        List all projects and their topics, filtered by an optional
+        search pattern.
+        """
+        for group in self.api.groups.list(search=self.group_filter,
+                                          per_page=MAX_GROUPS):
+            for project in group.projects.list(search=self.project_filter):
+                project = Project(self.api, project)
+                if (self.empty and not project.topic_count) or \
+                        (not self.empty and project.topic_count):
+                    yield project
+
+    def show(self):
+        """Display all found projects and their topics."""
+        for project in self.projects():
+            project.show_topics()
+
+    def set(self, new_topics):
+        """Set a list of topics on the projects found."""
+        for project in self.projects():
+            project.set_topics(new_topics)

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,49 @@
+#!/usr/bin/env python3
 """
 Packaging setup for Concierge CLI.
 See: https://click.palletsprojects.com/en/7.x/setuptools/
 """
-from setuptools import setup
+from os.path import abspath, dirname, join
+from setuptools import find_packages, setup
+
+import concierge_cli as package
+
+
+def read_file(filename):
+    """Get the contents of a file"""
+    here = abspath(dirname(__file__))
+    with open(join(here, filename)) as file:
+        return file.read()
+
 
 setup(
     name='concierge-cli',
-    version='0.99.0.dev0',
-    py_modules=['cli'],
+    version=package.__version__,
+    license=package.__license__,
+    author=package.__author__,
+    author_email=package.__email__,
+    description=package.__doc__.strip(),
+    long_description=read_file('README.rst'),
+    long_description_content_type='text/x-rst',
+    url=package.__url__,
+    packages=find_packages(exclude=['test*']),
+    include_package_data=True,
+    keywords=['cli', 'gitlab', 'management'],
+    classifiers=[
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+    ],
+    python_requires='>=3.6',
     install_requires=[
         'Click',
     ],
     entry_points={
         'console_scripts': [
-            'concierge-cli = cli:main',
+            'concierge-cli = concierge_cli.cli:main',
         ],
     },
 )


### PR DESCRIPTION
The changes divide the monolithic module into a more fine-grained, neatly structured project.

Still missing are: (out of scope here)

- Test and CI setup
- Writing tests
- Automatic packaging setup
