### PR TITLE
 Add gitlab projects subcommand (list by tag)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,3 +63,17 @@ List all projects *with* topics now: (double-check)
 .. code-block:: console
 
     $ concierge-cli gitlab topics bar/foo
+
+Print a YAML list of all projects matching a topic:
+
+.. code-block:: console
+
+    $ concierge-cli gitlab projects --topic Puppet
+
+Update the list of modules Concierge manages with a specific configuration:
+
+.. code-block:: console
+
+    $ concierge-cli gitlab projects --topic Puppet > configs/foo-bar/managed_modules.yml
+    $ git add -v configs/foo-bar/managed_modules.yml
+    $ git status && git commit -m 'Added ...' && git push

--- a/concierge_cli/adapter.py
+++ b/concierge_cli/adapter.py
@@ -36,3 +36,7 @@ class Project:
         project = self.api.projects.get(self.group_project.id, lazy=True)
         project.tag_list = new_topics
         project.save()
+
+    def __str__(self):
+        """Project name and its namespace"""
+        return self.name


### PR DESCRIPTION
Adds another sub-command for `gitlab` to list all projects matching one or more specific tags.