### PR TITLE
Add groups subcommand (add user to groups, manage permissions)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,8 @@ properties of your Git repository projects.  Currently, GitLab is supported.
 
 .. _Concierge: https://hub.docker.com/r/vshn/concierge/
 
-Why I Should I Use This Tool?
------------------------------
+Why Should I Use This Tool?
+---------------------------
 
 Concierge-cli helps you analyze and bulk-update the repository projects you
 manage (e.g. set topics on projects, generate project lists for ModuleSync).

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,16 @@ From PyPI:
 Usage Patterns
 --------------
 
+#. Manage `project topics`_
+#. List projects by topic
+#. Manage `group membership`_ and permissions
+
+.. _project topics: https://docs.gitlab.com/ce/user/project/settings/
+.. _group membership: https://docs.gitlab.com/ce/user/group/#add-users-to-a-group
+
+Manage topics
+^^^^^^^^^^^^^
+
 List all projects (for a private GitLab) that have no topics yet:
 
 .. code-block:: console
@@ -64,6 +74,9 @@ List all projects *with* topics now: (double-check)
 
     $ concierge-cli gitlab topics bar/foo
 
+List projects
+^^^^^^^^^^^^^
+
 Print a YAML list of all projects matching a topic:
 
 .. code-block:: console
@@ -77,3 +90,38 @@ Update the list of modules Concierge manages with a specific configuration:
     $ concierge-cli gitlab projects --topic Puppet > configs/foo-bar/managed_modules.yml
     $ git add -v configs/foo-bar/managed_modules.yml
     $ git status && git commit -m 'Added ...' && git push
+
+Group membership
+^^^^^^^^^^^^^^^^
+
+**Preparation:** You need an `access token`_ of an administrator user to
+list all groups and make changes to any group membership.
+
+.. _access token: https://gitlab.com/profile/personal_access_tokens
+
+List all groups where user is not yet a member of:
+
+.. code-block:: console
+
+    $ concierge-cli gitlab --token *s3cr3t* groups --no-member my.user.name
+
+Add user to all those groups:
+
+.. code-block:: console
+
+    $ concierge-cli gitlab --token *s3cr3t* groups --no-member my.user.name \
+                           --set-permission maintainer
+
+List a user's group memberships and permissions:
+
+.. code-block:: console
+
+    $ concierge-cli gitlab --token *s3cr3t* groups my.user.name
+
+Remove a user from selected groups:
+
+.. code-block:: console
+
+    $ concierge-cli gitlab --token *s3cr3t* groups my.user.name \
+                           --group-filter a-group-name \
+                           --set-permission none

--- a/concierge_cli/adapter.py
+++ b/concierge_cli/adapter.py
@@ -1,6 +1,7 @@
 """
 Concierge repository projects management CLI.
 """
+from .constants import GITLAB_PERMISSION_NAMES
 
 
 class Project:
@@ -40,3 +41,24 @@ class Project:
     def __str__(self):
         """Project name and its namespace"""
         return self.name
+
+
+class GroupMembership:
+    """
+    Adapter wrapping a group from a repository service API
+    """
+
+    def __init__(self, group, user):
+        """A GitLab API group, currently."""
+        self.group = group
+        self.user = user
+        member = self.group.members.get(self.user.id)
+        self.is_member = member is not None
+        self.access_level = 'n/a' if not member else \
+            GITLAB_PERMISSION_NAMES[member.access_level]
+
+    def __str__(self):
+        """Textual information about the group membership"""
+        return f"Group {self.group.full_path}: " \
+               f"{self.user.username} has " \
+               f"access level '{self.access_level}'"

--- a/concierge_cli/cli.py
+++ b/concierge_cli/cli.py
@@ -6,7 +6,8 @@ import click
 from gitlab.exceptions import GitlabError
 from requests.exceptions import RequestException
 
-from .manager import DEFAULT_GITLAB_URI, ProjectManager, TopicManager
+from .constants import GITLAB_DEFAULT_URI
+from .manager import ProjectManager, TopicManager
 
 
 @click.group()
@@ -19,7 +20,7 @@ def concierge_cli():
                             'in a configuration file (see '
                             'https://python-gitlab.readthedocs.io '
                             '> Configuration > Files), default: %s' %
-                            DEFAULT_GITLAB_URI)
+                            GITLAB_DEFAULT_URI)
 @click.option('--token', help='Optional access token. Anonymous access '
                               'if none is supplied.')
 @click.pass_context

--- a/concierge_cli/cli.py
+++ b/concierge_cli/cli.py
@@ -6,7 +6,7 @@ import click
 from gitlab.exceptions import GitlabError
 from requests.exceptions import RequestException
 
-from .constants import GITLAB_DEFAULT_URI
+from .constants import GITLAB_DEFAULT_URI, GITLAB_PERMISSIONS
 from .manager import GroupManager, ProjectManager, TopicManager
 
 
@@ -107,8 +107,11 @@ def projects(ctx, group_project_filter, topic):
               help='List only groups that match or contain a specific name.')
 @click.option('--member/--no-member', default=True,
               help='Select groups where user is (not) a member of.')
+@click.option('--set-permission',
+              type=click.Choice(GITLAB_PERMISSIONS.keys()),
+              help='Set user permission level on all matching groups.')
 @click.pass_context
-def groups(ctx, username, group_filter, member):
+def groups(ctx, username, group_filter, member, set_permission):
     """
     Manage the access level for a user on GitLab groups.
     """
@@ -120,7 +123,10 @@ def groups(ctx, username, group_filter, member):
         is_member=member,
         username=username,
     )
-    group_manager.show()
+    if set_permission:
+        group_manager.set(set_permission)
+    else:
+        group_manager.show()
 
 
 def main():

--- a/concierge_cli/cli.py
+++ b/concierge_cli/cli.py
@@ -23,10 +23,12 @@ def concierge_cli():
                             GITLAB_DEFAULT_URI)
 @click.option('--token', help='Optional access token. Anonymous access '
                               'if none is supplied.')
+@click.option('--insecure/--no-insecure',
+              help='Disable SSL certificate check and related warnings.')
 @click.pass_context
-def gitlab(ctx, uri, token):
+def gitlab(ctx, uri, token, insecure):
     """GitLab sub-commands."""
-    ctx.obj = dict(uri=uri, token=token)
+    ctx.obj = dict(uri=uri, token=token, insecure=insecure)
 
 
 @gitlab.command()
@@ -58,6 +60,7 @@ def topics(ctx, group_project_filter, empty, set_topic):
     topic_manager = TopicManager(
         uri=ctx.obj.get('uri'),
         token=ctx.obj.get('token'),
+        insecure=ctx.obj.get('insecure'),
         group_filter=group_filter,
         project_filter=project_filter,
         empty=empty,
@@ -94,6 +97,7 @@ def projects(ctx, group_project_filter, topic):
     project_manager = ProjectManager(
         uri=ctx.obj.get('uri'),
         token=ctx.obj.get('token'),
+        insecure=ctx.obj.get('insecure'),
         group_filter=group_filter,
         project_filter=project_filter,
         topic_list=list(topic),
@@ -119,6 +123,7 @@ def groups(ctx, username, group_filter, member, set_permission):
     group_manager = GroupManager(
         uri=ctx.obj.get('uri'),
         token=ctx.obj.get('token'),
+        insecure=ctx.obj.get('insecure'),
         group_filter=group_filter,
         is_member=member,
         username=username,

--- a/concierge_cli/cli.py
+++ b/concierge_cli/cli.py
@@ -7,7 +7,7 @@ from gitlab.exceptions import GitlabError
 from requests.exceptions import RequestException
 
 from .constants import GITLAB_DEFAULT_URI
-from .manager import ProjectManager, TopicManager
+from .manager import GroupManager, ProjectManager, TopicManager
 
 
 @click.group()
@@ -101,6 +101,28 @@ def projects(ctx, group_project_filter, topic):
     project_manager.show()
 
 
+@gitlab.command()
+@click.argument('username')
+@click.option('--group-filter', default='',
+              help='List only groups that match or contain a specific name.')
+@click.option('--member/--no-member', default=True,
+              help='Select groups where user is (not) a member of.')
+@click.pass_context
+def groups(ctx, username, group_filter, member):
+    """
+    Manage the access level for a user on GitLab groups.
+    """
+
+    group_manager = GroupManager(
+        uri=ctx.obj.get('uri'),
+        token=ctx.obj.get('token'),
+        group_filter=group_filter,
+        is_member=member,
+        username=username,
+    )
+    group_manager.show()
+
+
 def main():
     """Main entry point for the CLI"""
     try:
@@ -109,6 +131,8 @@ def main():
         raise SystemExit('%s (GitLab)' % err.error_message)
     except RequestException as req:
         raise SystemExit(req)
+    except Exception as other:
+        raise SystemExit(other)
 
 
 if __name__ == '__main__':

--- a/concierge_cli/constants.py
+++ b/concierge_cli/constants.py
@@ -1,0 +1,22 @@
+"""
+Constants for Concierge CLI.
+"""
+import gitlab
+
+GITLAB_DEFAULT_URI = 'https://gitlab.com'
+GITLAB_PERMISSIONS = {
+    'owner': gitlab.OWNER_ACCESS,
+    'maintainer': gitlab.MAINTAINER_ACCESS,
+    'developer': gitlab.DEVELOPER_ACCESS,
+    'reporter': gitlab.REPORTER_ACCESS,
+    'guest': gitlab.GUEST_ACCESS,
+    'none': 0,
+}
+GITLAB_PERMISSION_NAMES = {
+    gitlab.OWNER_ACCESS: 'owner',
+    gitlab.MAINTAINER_ACCESS: 'maintainer',
+    gitlab.DEVELOPER_ACCESS: 'developer',
+    gitlab.REPORTER_ACCESS: 'reporter',
+    gitlab.GUEST_ACCESS: 'guest',
+    0: 'none',
+}

--- a/concierge_cli/constants.py
+++ b/concierge_cli/constants.py
@@ -10,7 +10,7 @@ GITLAB_PERMISSIONS = {
     'developer': gitlab.DEVELOPER_ACCESS,
     'reporter': gitlab.REPORTER_ACCESS,
     'guest': gitlab.GUEST_ACCESS,
-    'none': 0,
+    'none': None,
 }
 GITLAB_PERMISSION_NAMES = {
     gitlab.OWNER_ACCESS: 'owner',
@@ -18,5 +18,5 @@ GITLAB_PERMISSION_NAMES = {
     gitlab.DEVELOPER_ACCESS: 'developer',
     gitlab.REPORTER_ACCESS: 'reporter',
     gitlab.GUEST_ACCESS: 'guest',
-    0: 'none',
+    None: 'none',
 }

--- a/concierge_cli/manager.py
+++ b/concierge_cli/manager.py
@@ -13,7 +13,7 @@ class GitlabAPI:
     Establishes an API connection to a GitLab instance.
     """
 
-    def __init__(self, uri=None, token=None):
+    def __init__(self, uri, token, insecure):
         """
         Connects to a GitLab instance using connection details from one of the
         local configuration files (see https://python-gitlab.readthedocs.io >
@@ -30,6 +30,13 @@ class GitlabAPI:
         if uri:
             self.api = Gitlab(uri, private_token=token, per_page=100)
 
+        if insecure:
+            from warnings import filterwarnings
+            from urllib3.exceptions import InsecureRequestWarning
+
+            filterwarnings('ignore', category=InsecureRequestWarning)
+            self.api.ssl_verify = False
+
 
 class TopicManager(GitlabAPI):
     """
@@ -37,11 +44,11 @@ class TopicManager(GitlabAPI):
     """
 
     def __init__(self, group_filter, project_filter, empty,
-                 uri=None, token=None):
+                 uri=None, token=None, insecure=False):
         """
         A topics filter by group, project and topic state (set or not set).
         """
-        super().__init__(uri, token)
+        super().__init__(uri, token, insecure)
         self.group_filter = group_filter
         self.project_filter = project_filter
         self.empty = empty
@@ -76,11 +83,11 @@ class ProjectManager(GitlabAPI):
     """
 
     def __init__(self, group_filter, project_filter, topic_list,
-                 uri=None, token=None):
+                 uri=None, token=None, insecure=False):
         """
         A projects filter by group, project and topic(s).
         """
-        super().__init__(uri, token)
+        super().__init__(uri, token, insecure)
         self.group_filter = group_filter
         self.project_filter = project_filter
         self.topic_list = topic_list
@@ -110,11 +117,11 @@ class GroupManager(GitlabAPI):
     """
 
     def __init__(self, group_filter, username, is_member=True,
-                 uri=None, token=None):
+                 uri=None, token=None, insecure=False):
         """
         A groups filter by group, project and topic(s).
         """
-        super().__init__(uri, token)
+        super().__init__(uri, token, insecure)
 
         users = self.api.users.list(username=username)
         if len(users) != 1:

--- a/concierge_cli/manager.py
+++ b/concierge_cli/manager.py
@@ -5,7 +5,7 @@ from gitlab import Gitlab
 from gitlab.config import GitlabConfigMissingError
 
 from .adapter import GroupMembership, Project
-from .constants import GITLAB_DEFAULT_URI, GITLAB_PERMISSIONS
+from .constants import GITLAB_DEFAULT_URI
 
 
 class GitlabAPI:
@@ -110,11 +110,12 @@ class GroupManager(GitlabAPI):
     """
 
     def __init__(self, group_filter, username, is_member=True,
-                 set_permissions=None, uri=None, token=None):
+                 uri=None, token=None):
         """
         A groups filter by group, project and topic(s).
         """
         super().__init__(uri, token)
+
         users = self.api.users.list(username=username)
         if len(users) != 1:
             raise ValueError('No such user: %s' % username)
@@ -122,8 +123,6 @@ class GroupManager(GitlabAPI):
         self.group_filter = group_filter
         self.user = users[0]
         self.is_member = is_member
-        self.permission_level = GITLAB_PERMISSIONS[set_permissions] \
-            if set_permissions else None
 
     def groups(self):
         """
@@ -144,3 +143,10 @@ class GroupManager(GitlabAPI):
         """
         for group_user in self.groups():
             print(group_user)
+
+    def set(self, permission_name):
+        """
+        Display all found groups and the user's current access level.
+        """
+        for group_user in self.groups():
+            group_user.set_membership(permission_name)

--- a/concierge_cli/manager.py
+++ b/concierge_cli/manager.py
@@ -146,7 +146,7 @@ class GroupManager(GitlabAPI):
 
     def set(self, permission_name):
         """
-        Display all found groups and the user's current access level.
+        Ensure the user has privileges to access the selected groups.
         """
         for group_user in self.groups():
             group_user.set_membership(permission_name)

--- a/concierge_cli/manager.py
+++ b/concierge_cli/manager.py
@@ -5,9 +5,7 @@ from gitlab import Gitlab
 from gitlab.config import GitlabConfigMissingError
 
 from .adapter import Project
-
-DEFAULT_GITLAB_URI = 'https://gitlab.com'
-MAX_GROUPS = 999_999
+from .constants import GITLAB_DEFAULT_URI
 
 
 class GitlabAPI:
@@ -27,10 +25,10 @@ class GitlabAPI:
             try:
                 self.api = Gitlab.from_config()
             except GitlabConfigMissingError:
-                uri = DEFAULT_GITLAB_URI
+                uri = GITLAB_DEFAULT_URI
 
         if uri:
-            self.api = Gitlab(uri, private_token=token)
+            self.api = Gitlab(uri, private_token=token, per_page=100)
 
 
 class TopicManager(GitlabAPI):
@@ -53,10 +51,9 @@ class TopicManager(GitlabAPI):
         List all projects and their topics, filtered by an optional
         search pattern.
         """
-        for group in self.api.groups.list(search=self.group_filter,
-                                          per_page=MAX_GROUPS):
+        for group in self.api.groups.list(search=self.group_filter, all=True):
             for group_project in \
-                    group.projects.list(search=self.project_filter):
+                    group.projects.list(search=self.project_filter, all=True):
                 project = Project(self.api, group_project)
                 if (self.empty and not project.topic_count) or \
                         (not self.empty and project.topic_count):
@@ -93,10 +90,9 @@ class ProjectManager(GitlabAPI):
         List all projects and their topics, filtered by an optional
         search pattern.
         """
-        for group in self.api.groups.list(search=self.group_filter,
-                                          per_page=MAX_GROUPS):
+        for group in self.api.groups.list(search=self.group_filter, all=True):
             for group_project in \
-                    group.projects.list(search=self.project_filter):
+                    group.projects.list(search=self.project_filter, all=True):
                 project = Project(self.api, group_project)
                 matched_tags = set(project.topic_list) & set(self.topic_list)
                 if matched_tags or not self.topic_list:

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,7 @@ import concierge_cli as package
 
 def read_file(filename):
     """Get the contents of a file"""
-    here = abspath(dirname(__file__))
-    with open(join(here, filename)) as file:
+    with open(join(abspath(dirname(__file__)), filename)) as file:
         return file.read()
 
 


### PR DESCRIPTION
These changes add a new CLI subcommand to the `gitlab` command, which allows:

- Listing groups where a user is a member or has no membership
- Adding a user to a group or update an existing access level

As usual, to perform the add and update operations you must use an access token of a privileged user (GitLab administrator).