### PR TITLE
Add descriptions to Tox target sections

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,13 +9,16 @@ envlist =
     bandit
     readme
     requirements
+    safety
     clean
 
 [testenv]
+description = Unit tests and doctests
 deps = pytest
 commands = pytest
 
 [testenv:clean]
+description = Remove Python bytecode and other debris
 deps = pyclean
 commands =
     py3clean -v {toxinidir}
@@ -24,30 +27,40 @@ whitelist_externals =
     rm
 
 [testenv:bandit]
+description = PyCQA security linter
 deps = bandit<1.6
 commands = bandit -r .
 
 [testenv:flake8]
+description = Static code analysis and code style
 deps = flake8
 commands = flake8
 
 [testenv:pylint]
+description = Check for errors and code smells
 deps = pylint
 commands = pylint concierge_cli setup
 
 [testenv:readme]
+description = Ensure README renders on PyPI
 deps = twine
 commands =
     {envpython} setup.py -q sdist bdist_wheel
     twine check dist/*
 
 [testenv:requirements]
+description = Update package requirements
 deps =
     pip-tools
     pipenv
 commands =
     pip-compile --output-file=requirements.txt requirements.in --upgrade
     pipenv update
+
+[testenv:safety]
+description = Check for vulnerable dependencies
+deps = safety
+commands = safety check -r requirements.txt
 
 [bandit]
 exclude = .tox,build,dist,tests
@@ -56,4 +69,8 @@ exclude = .tox,build,dist,tests
 exclude = .tox,build,dist,concierge_cli.egg-info
 
 [pytest]
-addopts = --strict --verbose
+addopts =
+    --color=yes
+    --doctest-modules
+    --strict
+    --verbose


### PR DESCRIPTION
These changes allow to show some simple "help" by running: `tox -l -v`

- Adds descriptions to all Tox target sections
- Adds `safety` to check for vulnerabilities