### PR TITLE
Add CLI command to manage GitLab merge requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,11 +54,31 @@ You can use Pipenv to work around this limitation:
 
 .. _python-gitlab: https://pypi.org/project/python-gitlab/
 
+Preparation
+-----------
+
+You need an `access token`_ of a GitLab user to access resources through the
+API. For groups and group membership this needs to be an administrator user.
+You may also want to `disable notifications`_ of the user(s) you plan to
+perform bulk updates on, to avoid sending out massive amounts of emails.
+
+.. _access token: https://gitlab.com/profile/personal_access_tokens
+.. _disable notifications: https://gitlab.com/profile/notifications
+
+Set the GitLab URI and TOKEN as environment variables (if you want to avoid
+using the ``--token`` and/or ``--uri`` options):
+
+.. code-block:: console
+
+    $ export CONCIERGE_GITLAB_URI=https://git.example.com/
+    $ export CONCIERGE_GITLAB_TOKEN=<redacted>
+
 Usage Patterns
 --------------
 
 #. Manage `project topics`_
 #. List projects by topic
+#. List (and merge) merge requests by project
 #. Manage `group membership`_ and permissions
 
 .. _project topics: https://docs.gitlab.com/ce/user/project/settings/
@@ -108,24 +128,19 @@ Update the list of modules Concierge manages with a specific configuration:
     $ git add -v configs/foo-bar/managed_modules.yml
     $ git status && git commit -m 'Added ...' && git push
 
-Group membership
-^^^^^^^^^^^^^^^^
+Merge requests
+^^^^^^^^^^^^^^
 
-**Preparation:** You need an `access token`_ of an administrator user to
-list all groups and make changes to any group membership. You may also want
-to `disable notifications`_ of the user(s) you plan to perform bulk updates
-on, to avoid sending out a massive amount of emails.
-
-.. _access token: https://gitlab.com/profile/personal_access_tokens
-.. _disable notifications: https://gitlab.com/profile/notifications
-
-Set the GitLab URI and TOKEN as environment variables (if you want to avoid
-using the ``--token`` and/or ``--uri`` options):
+List of all merge requests of a project, optionally matching labels:
 
 .. code-block:: console
 
-    $ export CONCIERGE_GITLAB_URI=https://git.example.com/
-    $ export CONCIERGE_GITLAB_TOKEN=<redacted>
+    $ concierge-cli gitlab mrs mygroup/myproject --label mylabel
+
+Add ``--merge yes`` to trigger merging all found requests.
+
+Group membership
+^^^^^^^^^^^^^^^^
 
 List all groups where user is not yet a member of:
 

--- a/concierge_cli/__init__.py
+++ b/concierge_cli/__init__.py
@@ -4,5 +4,5 @@ Concierge repository projects management CLI.
 __author__ = 'VSHN AG'
 __email__ = 'tech@vshn.ch'
 __url__ = 'https://github.com/vshn/concierge-cli'
-__version__ = '1.3.0'
+__version__ = '1.4.0'
 __license__ = 'BSD-3-Clause'

--- a/concierge_cli/adapter.py
+++ b/concierge_cli/adapter.py
@@ -19,6 +19,9 @@ class Project:
         self.topic_count = len(self.topic_list)
         self.api = api
 
+        # a full-featured project (a group project has limited features)
+        self.project = self.api.projects.get(self.group_project.id, lazy=True)
+
     def show_topics(self):
         """Display the project name and project topics"""
         if self.topic_count:
@@ -35,13 +38,17 @@ class Project:
         else:
             print(f"Setting new topics on {self.name}: {new_topics}")
 
-        # get a full-featured project (a group project has limited features)
-        project = self.api.projects.get(self.group_project.id, lazy=True)
-        project.tag_list = new_topics
-        project.save()
+        self.project.tag_list = new_topics
+        self.project.save()
 
         self.topic_list = new_topics
         self.topic_count = len(new_topics)
+
+    def get_mergerequests(self, state='opened', labels=(), wip='no'):
+        """Return a list of the project's merge requests"""
+        return self.project.mergerequests.list(state=state,
+                                               labels=labels,
+                                               wip=wip)
 
     def __str__(self):
         """Project name and its namespace"""

--- a/concierge_cli/cli.py
+++ b/concierge_cli/cli.py
@@ -143,11 +143,11 @@ def main():
     try:
         concierge_cli()
     except GitlabError as err:
-        raise SystemExit('%s (GitLab)' % err.error_message)
+        raise SystemExit('%s 💣 GitLab error. Aborting.' % err.error_message)
     except RequestException as req:
-        raise SystemExit(req)
+        raise SystemExit('%s 💣 Communication error. Aborting.' % req)
     except Exception as other:
-        raise SystemExit(other)
+        raise SystemExit('%s 💣 Application error. Aborting.' % other)
 
 
 if __name__ == '__main__':

--- a/concierge_cli/cli.py
+++ b/concierge_cli/cli.py
@@ -111,9 +111,12 @@ def mrs(ctx, group_project_filter, label, merge):
         group_filter=group_filter,
         project_filter=project_filter,
         labels=list(label),
-        merge=merge,
+        merge_style=merge,
     )
-    mr_manager.show()
+    if merge in ['yes', 'automatic']:
+        mr_manager.merge_all()
+    else:
+        mr_manager.show()
 
 
 @gitlab.command()
@@ -164,7 +167,6 @@ def groups(ctx, username, group_filter, member, set_permission):
     """
     Manage the access level for a user on GitLab groups.
     """
-
     group_manager = GroupManager(
         uri=ctx.obj.get('uri'),
         token=ctx.obj.get('token'),

--- a/concierge_cli/manager.py
+++ b/concierge_cli/manager.py
@@ -149,7 +149,7 @@ class MergeRequestManager(GitlabAPI):
 
     def confirm_and_merge(self, merge_request):
         """Ask for confirmation interactively, then merge the MR."""
-        choice = input("Proceed with merging"
+        choice = input("Proceed with merging"  # nosec
                        f" ✓ {merge_request.references['full']}:"
                        f" {merge_request.title} ? (y/n) [n] ")
         if choice == 'y':

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,6 +106,27 @@ def test_gitlab_mrs_show(mock_manager):
     """
     launch_cli('gitlab', 'mrs', 'some/project', '--label', 'foo')
     assert mock_manager().show.called
+    assert not mock_manager().merge_all.called
+
+
+@patch('concierge_cli.cli.MergeRequestManager')
+def test_gitlab_mrs_merge_yes(mock_manager):
+    """
+    Does mrs --merge=yes trigger the manager's merge_all method?
+    """
+    launch_cli('gitlab', 'mrs', 'some/project', '--merge', 'yes')
+    assert mock_manager().merge_all.called
+    assert not mock_manager().show.called
+
+
+@patch('concierge_cli.cli.MergeRequestManager')
+def test_gitlab_mrs_merge_automatic(mock_manager):
+    """
+    Does mrs --merge=automatic trigger the manager's merge_all method?
+    """
+    launch_cli('gitlab', 'mrs', 'some/project', '--merge', 'automatic')
+    assert mock_manager().merge_all.called
+    assert not mock_manager().show.called
 
 
 def test_gitlab_projects_command():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,6 +91,23 @@ def test_gitlab_envvars(mock_manager):
     assert mock_manager.mock_calls[0] == expected_call
 
 
+def test_gitlab_mrs_command():
+    """
+    Is subcommand available?
+    """
+    exit_status = os.system('concierge-cli gitlab mrs --help')
+    assert exit_status == 0
+
+
+@patch('concierge_cli.cli.MergeRequestManager')
+def test_gitlab_mrs_show(mock_manager):
+    """
+    Does mrs command run the manager's show method? (by default)
+    """
+    launch_cli('gitlab', 'mrs', 'some/project', '--label', 'foo')
+    assert mock_manager().show.called
+
+
 def test_gitlab_projects_command():
     """
     Is subcommand available?

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -3,19 +3,33 @@ Tests for concierge-cli's manager classes
 """
 from gitlab import Gitlab
 from gitlab.config import GitlabConfigMissingError
-from unittest.mock import patch
+from unittest.mock import call, patch
 from urllib3.exceptions import InsecureRequestWarning
 
 from concierge_cli.manager import (
     # GITLAB_DEFAULT_URI,
     GitlabAPI,
     GroupManager,
+    MergeRequestManager,
     ProjectManager,
     TopicManager,
 )
 
 TEST_URI = 'https://some.gitlab.host'
 TEST_TOKEN = '1234567890abcdefghijklmnopqrstuvwxyz'
+
+
+def mock_ref(iid):
+    return dict(full='mockedgroup/mockedproject!%s' % iid)
+
+
+class MergeRequestMock:
+    merge_status = 'can_be_merged'
+    references = mock_ref(42)
+    title = 'My mocked merge request'
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(**kwargs)
 
 
 @patch.object(Gitlab, 'from_config')
@@ -144,6 +158,35 @@ def test_projectmanager_show(mock_project):
 
         project_manager.show()
         assert mock_manager_projects.called
+
+
+@patch('builtins.print')
+def test_mergerequestmanager_show(mock_print):
+    """
+    Does show() method call merge_requests() and prints all MRs?
+    """
+    with patch.object(MergeRequestManager, 'merge_requests', return_value=[
+        MergeRequestMock(title='Foo', references=mock_ref(3)),
+        MergeRequestMock(title='Bar', merge_status='cannot_be_merged'),
+        MergeRequestMock(title='Baz', references=mock_ref(17)),
+    ]) as mock_manager_merge_requests:
+
+        mr_manager = MergeRequestManager(
+            group_filter='',
+            project_filter='',
+            labels=[],
+            merge='no',
+        )
+        assert isinstance(mr_manager, GitlabAPI)
+
+        mr_manager.show()
+        assert mock_manager_merge_requests.called
+        assert mock_print.mock_calls == [
+            call('Open merge requests:'),
+            call('✓ mockedgroup/mockedproject!3: Foo'),
+            call('✗ mockedgroup/mockedproject!42: Bar'),
+            call('✓ mockedgroup/mockedproject!17: Baz'),
+        ]
 
 
 @patch('concierge_cli.adapter.GroupMembership')

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -161,32 +161,31 @@ def test_projectmanager_show(mock_project):
 
 
 @patch('builtins.print')
-def test_mergerequestmanager_show(mock_print):
+@patch.object(MergeRequestManager, 'merge_requests', return_value=[
+    MergeRequestMock(title='Foo', references=mock_ref(3)),
+    MergeRequestMock(title='Bar', merge_status='cannot_be_merged'),
+    MergeRequestMock(title='Baz', references=mock_ref(17)),
+])
+def test_mergerequestmanager_show(mock_manager_merge_requests, mock_print):
     """
     Does show() method call merge_requests() and prints all MRs?
     """
-    with patch.object(MergeRequestManager, 'merge_requests', return_value=[
-        MergeRequestMock(title='Foo', references=mock_ref(3)),
-        MergeRequestMock(title='Bar', merge_status='cannot_be_merged'),
-        MergeRequestMock(title='Baz', references=mock_ref(17)),
-    ]) as mock_manager_merge_requests:
+    mr_manager = MergeRequestManager(
+        group_filter='',
+        project_filter='',
+        labels=[],
+        merge='no',
+    )
+    assert isinstance(mr_manager, GitlabAPI)
 
-        mr_manager = MergeRequestManager(
-            group_filter='',
-            project_filter='',
-            labels=[],
-            merge='no',
-        )
-        assert isinstance(mr_manager, GitlabAPI)
-
-        mr_manager.show()
-        assert mock_manager_merge_requests.called
-        assert mock_print.mock_calls == [
-            call('Open merge requests:'),
-            call('✓ mockedgroup/mockedproject!3: Foo'),
-            call('✗ mockedgroup/mockedproject!42: Bar'),
-            call('✓ mockedgroup/mockedproject!17: Baz'),
-        ]
+    mr_manager.show()
+    assert mock_manager_merge_requests.called
+    assert mock_print.mock_calls == [
+        call('Open merge requests:'),
+        call('✓ mockedgroup/mockedproject!3: Foo'),
+        call('✗ mockedgroup/mockedproject!42: Bar'),
+        call('✓ mockedgroup/mockedproject!17: Baz'),
+    ]
 
 
 @patch('concierge_cli.adapter.GroupMembership')


### PR DESCRIPTION
Adds the `mrs` CLI command, which allows for GitLab repositories to

1. list merge requests, optionally filtered by group name, project name, and/or labels
1. merge the identified merge requests, guarded by interactive confirmation or in a fully automatic fashion.

Tests are included, of course.

**Relates to:** VT-1022