### PR TITLE
Fix empty CONCIERGE_GITLAB_URI environment value has no default

### DIFF
--- a/concierge_cli/__init__.py
+++ b/concierge_cli/__init__.py
@@ -4,5 +4,5 @@ Concierge repository projects management CLI.
 __author__ = 'VSHN AG'
 __email__ = 'tech@vshn.ch'
 __url__ = 'https://github.com/vshn/concierge-cli'
-__version__ = '1.4.0'
+__version__ = '1.4.1'
 __license__ = 'BSD-3-Clause'

--- a/concierge_cli/cli.py
+++ b/concierge_cli/cli.py
@@ -20,11 +20,12 @@ def concierge_cli():
 
 @concierge_cli.group()
 @click.option('--uri', envvar='CONCIERGE_GITLAB_URI',
-              help='Location of the GitLab host (default: %s). Alternatively,'
-                   ' you may set the CONCIERGE_GITLAB_URI environment'
-                   ' variable, or specify a host in a configuration file (see'
+              default=GITLAB_DEFAULT_URI, show_default=True,
+              help='Location of the GitLab host. Alternatively, you may set'
+                   ' the CONCIERGE_GITLAB_URI environment variable, or'
+                   ' specify a host in a configuration file (see'
                    ' https://python-gitlab.readthedocs.io > CLI usage >'
-                   ' Configuration > Files).' % GITLAB_DEFAULT_URI)
+                   ' Configuration > Files).')
 @click.option('--token', envvar='CONCIERGE_GITLAB_TOKEN',
               help='Optional access token (access is anonymous if none is'
                    ' supplied). Alternatively, you may set the'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,6 +74,24 @@ def test_gitlab_groups_set(mock_manager):
 
 
 @patch('concierge_cli.cli.GroupManager')
+def test_gitlab_envvar_defaults(mock_manager):
+    """
+    Are env variable defaults used if set the related values?
+    """
+    expected_call = call(
+        group_filter='', insecure=False, is_member=False,
+        token='secret-access-token',
+        uri=concierge_cli.constants.GITLAB_DEFAULT_URI,
+        username='my.user.name')
+
+    with EnvironContext(CONCIERGE_GITLAB_TOKEN='secret-access-token'), \
+            EnvironContext(CONCIERGE_GITLAB_URI=None):
+        launch_cli('gitlab', 'groups', '--no-member', 'my.user.name')
+
+    assert mock_manager.mock_calls[0] == expected_call
+
+
+@patch('concierge_cli.cli.GroupManager')
 def test_gitlab_envvars(mock_manager):
     """
     Do env variables set the related values?


### PR DESCRIPTION
This fixes a bug that allows the `uri` value to be `None` when the `CONCIERGE_GITLAB_URI` environment variable is set to "" (empty).