### PR TITLE
Also show pipeline status in list of merge requests

### DIFF
--- a/concierge_cli/__init__.py
+++ b/concierge_cli/__init__.py
@@ -4,5 +4,5 @@ Concierge repository projects management CLI.
 __author__ = 'VSHN AG'
 __email__ = 'tech@vshn.ch'
 __url__ = 'https://github.com/vshn/concierge-cli'
-__version__ = '1.4.1'
+__version__ = '1.5.0'
 __license__ = 'BSD-3-Clause'


### PR DESCRIPTION
Makes the `gitlab mrs` command display another check mark (✓) or ballot (✗) for each merge request, representing the status of the last pipeline that ran for the MR on GitLab.

Only if both the MR is mergeable and the last pipeline succeeded the MR will be allowed to be merged from the command line.