### PR TITLE
Add --debug option to all CLI levels (decorator)

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -221,7 +221,16 @@ def test_handle_other_errors(mock_cli):
 def test_debug_option(mock_manager, capsys):
     """
     Does --debug show a full stacktrace instead of a short error message?
+    Can it be placed at any position in the argument list?
     """
+    with ArgvContext('concierge-cli', 'gitlab', 'mrs', '--debug'), \
+            pytest.raises(RuntimeError), pytest.raises(SystemExit):
+        concierge_cli.cli.main()
+
+    with ArgvContext('concierge-cli', 'gitlab', '--debug', 'mrs'), \
+            pytest.raises(RuntimeError), pytest.raises(SystemExit):
+        concierge_cli.cli.main()
+
     with ArgvContext('concierge-cli', '--debug', 'gitlab', 'mrs'), \
-            pytest.raises(RuntimeError):
+            pytest.raises(RuntimeError), pytest.raises(SystemExit):
         concierge_cli.cli.main()


### PR DESCRIPTION
We would need options such as `--debug` to be global options. Unfortunately, Click doesn't support global options (or group options that are inherited). A deliberate design decision, as a core developer explains.

This option is implemented as a decorator in a way [similar to `--version` or `--help` in Click](https://github.com/pallets/click/blob/master/src/click/decorators.py#L347-L375). This way, while we still do have to add the decorator the each Click group or command, we don't need to add a `debug` argument to the function parameter list, at least.

Related discussion: https://github.com/pallets/click/issues/66