### PR TITLE
Ignore archived GitLab projects

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -46,11 +46,11 @@
         },
         "python-gitlab": {
             "hashes": [
-                "sha256:6461e0662cacceb795fb3ffd225391133cc11e0e760d0caf1c998c7ba955c771",
-                "sha256:e240b5c371d9e98c46c980d878c3f03cd83f3da6cda01d533db27fa3e0dd474f"
+                "sha256:61270e1f8ac24fe248f41834c840c6465d2e0b216493d3508d296a02960122c0",
+                "sha256:68b42aafd4b620ab2534ff78a52584c7f799e4e55d5ac297eab4263066e6f74b"
             ],
             "index": "pypi",
-            "version": "==2.4.0"
+            "version": "==2.5.0"
         },
         "requests": {
             "hashes": [
@@ -87,11 +87,11 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+                "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594",
+                "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==19.3.0"
+            "version": "==20.2.0"
         },
         "bandit": {
             "hashes": [
@@ -141,11 +141,11 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:2db287d71a284e22e5c2846042d0602465c7434d910406990d5b74df4afb0858",
-                "sha256:fa3b92da728a457dd75d62bb5f3eb2816d99a7fe6c67398e260637a40e3fafb5"
+                "sha256:080bf8e2cf1a2b907634761c2eaefbe83b69930c94c66ad11b65a8252959f912",
+                "sha256:1858f4fd089abe92ae465f01d5aaaf55e937eca565fb2c1fce35a51b5f85c910"
             ],
             "markers": "python_version >= '3.4'",
-            "version": "==3.1.7"
+            "version": "==3.1.8"
         },
         "importlib-metadata": {
             "hashes": [
@@ -172,11 +172,11 @@
         },
         "isort": {
             "hashes": [
-                "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1",
-                "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"
+                "sha256:171c5f365791073426b5ed3a156c2081a47f88c329161fd28228ff2da4c97ddb",
+                "sha256:ba91218eee31f1e300ecc079ef0c524cea3fc41bfbb979cbdf5fd3a889e3cfed"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==4.3.21"
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "version": "==5.5.2"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -214,11 +214,11 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5",
-                "sha256:b78134b2063dd214000685165d81c154522c3ee0a1c0d4d113c80361c234c5a2"
+                "sha256:6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20",
+                "sha256:9b30f12df9393f0d28af9210ff8efe48d10c94f73e5daf886f10c4b0b0b4f03c"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==8.4.0"
+            "version": "==8.5.0"
         },
         "packaging": {
             "hashes": [
@@ -230,10 +230,11 @@
         },
         "pbr": {
             "hashes": [
-                "sha256:07f558fece33b05caf857474a366dfcc00562bca13dd8b47b2b3e22d9f9bf55c",
-                "sha256:579170e23f8e0c2f24b0de612f71f648eccb79fb1322c814ae6b3c07b5ba23e8"
+                "sha256:14bfd98f51c78a3dd22a1ef45cf194ad79eee4a19e8e1a0d5c7f8e81ffe182ea",
+                "sha256:5adc0f9fc64319d8df5ca1e4e06eea674c26b80e6f00c530b18ce6a6592ead15"
             ],
-            "version": "==5.4.5"
+            "markers": "python_version >= '2.6'",
+            "version": "==5.5.0"
         },
         "pip-tools": {
             "hashes": [
@@ -277,11 +278,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:7dd78437f2d8d019717dbf287772d0b2dbdfd13fc016aa7faa08d67bccc46adc",
-                "sha256:d0ece7d223fe422088b0e8f13fa0a1e8eb745ebffcb8ed53d3e95394b6101a1c"
+                "sha256:bb4a908c9dadbc3aac18860550e870f58e1a02c9f2c204fdf5693d73be061210",
+                "sha256:bfe68f020f8a0fece830a22dd4d5dddb4ecc6137db04face4c3420a46a52239f"
             ],
             "index": "pypi",
-            "version": "==2.5.3"
+            "version": "==2.6.0"
         },
         "pyparsing": {
             "hashes": [
@@ -293,11 +294,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:85228d75db9f45e06e57ef9bf4429267f81ac7c0d742cc9ed63d09886a9fe6f4",
-                "sha256:8b6007800c53fdacd5a5c192203f4e531eb2a1540ad9c752e052ec0f7143dbad"
+                "sha256:0e37f61339c4578776e090c3b8f6b16ce4db333889d65d0efb305243ec544b40",
+                "sha256:c8f57c2a30983f469bf03e68cdfa74dc474ce56b8f280ddcb080dfd91df01043"
             ],
             "index": "pypi",
-            "version": "==6.0.1"
+            "version": "==6.0.2"
         },
         "pyyaml": {
             "hashes": [
@@ -333,11 +334,11 @@
         },
         "stevedore": {
             "hashes": [
-                "sha256:38791aa5bed922b0a844513c5f9ed37774b68edc609e5ab8ab8d8fe0ce4315e5",
-                "sha256:c8f4f0ebbc394e52ddf49de8bcc3cf8ad2b4425ebac494106bbc5e3661ac7633"
+                "sha256:5e1ab03eaae06ef6ce23859402de785f08d97780ed774948ef16c4652c41bc62",
+                "sha256:f845868b3a3a77a2489d226568abe7328b5c2d4f6a011cc759dfa99144a521f0"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.2.0"
+            "version": "==3.2.2"
         },
         "toml": {
             "hashes": [
@@ -348,11 +349,11 @@
         },
         "tox": {
             "hashes": [
-                "sha256:3d914480c46232c2d1a035482242535a26d76cc299e4fd28980c858463206f45",
-                "sha256:5c82e40046a91dbc80b6bd08321b13b4380d8ce3bcb5b62616cb17aaddefbb3a"
+                "sha256:e6318f404aff16522ff5211c88cab82b39af121735a443674e4e2e65f4e4637b",
+                "sha256:eb629ddc60e8542fd4a1956b2462e3b8771d49f1ff630cecceacaa0fbfb7605a"
             ],
             "index": "pypi",
-            "version": "==3.18.1"
+            "version": "==3.20.0"
         },
         "typed-ast": {
             "hashes": [
@@ -383,11 +384,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:8aa9c37b082664dbce2236fa420759c02d64109d8e6013593ad13914718a30fd",
-                "sha256:f14a0a98ea4397f0d926cff950361766b6a73cd5975ae7eb259d12919f819a25"
+                "sha256:43add625c53c596d38f971a465553f6318decc39d98512bc100fa1b1e839c8dc",
+                "sha256:e0305af10299a7fb0d69393d8f04cb2965dda9351140d11ac8db4e5e3970451b"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.0.29"
+            "version": "==20.0.31"
         },
         "wrapt": {
             "hashes": [

--- a/concierge_cli/__init__.py
+++ b/concierge_cli/__init__.py
@@ -4,5 +4,5 @@ Concierge repository projects management CLI.
 __author__ = 'VSHN AG'
 __email__ = 'tech@vshn.ch'
 __url__ = 'https://github.com/vshn/concierge-cli'
-__version__ = '1.6.0'
+__version__ = '1.7.0'
 __license__ = 'BSD-3-Clause'

--- a/concierge_cli/cli.py
+++ b/concierge_cli/cli.py
@@ -150,7 +150,7 @@ def mrs(ctx, group_project_filter, label, merge):
 @debug_option()
 def projects(ctx, group_project_filter, topic):
     """
-    List projects on GitLab, optionally by topic.
+    List projects on GitLab, optionally by topic, ignoring archived ones.
 
     Filter syntax:
 

--- a/concierge_cli/manager.py
+++ b/concierge_cli/manager.py
@@ -202,7 +202,8 @@ class ProjectManager(GitlabAPI):
         """
         for group in self.api.groups.list(search=self.group_filter, all=True):
             for group_project in \
-                    group.projects.list(search=self.project_filter, all=True):
+                    group.projects.list(search=self.project_filter, all=True,
+                                        archived=False):
                 project = Project(self.api, group_project)
                 matched_tags = set(project.topic_list) & set(self.topic_list)
                 if matched_tags or not self.topic_list:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -175,14 +175,14 @@ def test_projectmanager_show(mock_project):
 def test_projectmanager_projects_list_args():
     """
     Are groups.list() and group.projects.list() called with correct arguments?
-
-    1. Make `api.groups.list` return a list with a single item (a group)
-    2. Verify the call to `group.projects.list` uses the right arguments
     """
-    mock_group = Mock()
-    mock_groups_list = Mock(return_value=[mock_group])
+    # skip the loop body by having `group.projects.list` return an empty list
     mock_projects_list = Mock(return_value=[])
+    mock_group = Mock()
     mock_group.projects.list = mock_projects_list
+
+    # trigger `group.projects.list` once by a list with only a single group
+    mock_groups_list = Mock(return_value=[mock_group])
     mock_api = Mock()
     mock_api.groups.list = mock_groups_list
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -172,6 +172,40 @@ def test_projectmanager_show(mock_project):
         assert mock_manager_projects.called
 
 
+def test_projectmanager_projects_list_args():
+    """
+    Are groups.list() and group.projects.list() called with correct arguments?
+
+    1. Make `api.groups.list` return a list with a single item (a group)
+    2. Verify the call to `group.projects.list` uses the right arguments
+    """
+    mock_group = Mock()
+    mock_groups_list = Mock(return_value=[mock_group])
+    mock_projects_list = Mock(return_value=[])
+    mock_group.projects.list = mock_projects_list
+    mock_api = Mock()
+    mock_api.groups.list = mock_groups_list
+
+    project_manager = ProjectManager(
+        group_filter='foo',
+        project_filter='bar',
+        topic_list=[],
+        uri=TEST_URI,
+        token=TEST_TOKEN,
+        insecure=False,
+    )
+    project_manager.api = mock_api
+
+    list(project_manager.projects())
+
+    assert mock_groups_list.call_args_list == [
+        call(search='foo', all=True)
+    ]
+    assert mock_projects_list.call_args_list == [
+        call(search='bar', all=True, archived=False)
+    ]
+
+
 @patch('builtins.print')
 @patch.object(MergeRequestManager, 'merge_requests', return_value=[
     MergeRequestMock(title='Foo', references=mock_ref(3)),


### PR DESCRIPTION
When listing projects as potential candidates for MRs we want to ignore archived projects.

Related documentation: [API examples > Groups](https://python-gitlab.readthedocs.io/en/stable/gl_objects/groups.html?highlight=archived#examples)

I tried to also come up with a related test, but unfortunately I couldn't get it to work. If any of you has an idea and would give it a shot, feel free! :+1: It would be great to have a test in place for this.