### PR TITLE
Fix topic matching logic

### DIFF
--- a/concierge_cli/manager.py
+++ b/concierge_cli/manager.py
@@ -205,8 +205,9 @@ class ProjectManager(GitlabAPI):
                     group.projects.list(search=self.project_filter, all=True,
                                         archived=False):
                 project = Project(self.api, group_project)
-                matched_tags = set(project.topic_list) & set(self.topic_list)
-                if matched_tags or not self.topic_list:
+                topics_match = set(project.topic_list) \
+                    & set(self.topic_list) == set(self.topic_list)
+                if topics_match or not self.topic_list:
                     yield project
 
     def show(self):


### PR DESCRIPTION
The logic for matching topics is wrong here.
To correctly match the topics on a project with a list of provided topics, we need to do an intersection of both and do a strict test on the result with the provided topic.


Signed-off-by: Nicolas Bigler <nicolas.bigler@vshn.ch>