### PR TITLE
Fix use of PyClean in Tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,11 +24,7 @@ commands =
 description = Remove Python bytecode and other debris
 skip_install = true
 deps = pyclean
-commands =
-    pyclean {posargs} {toxinidir}
-    rm -rf .tox/ concierge_cli.egg-info/ build/ dist/
-whitelist_externals =
-    rm
+commands = pyclean {posargs:. --debris}
 
 [testenv:bandit]
 description = PyCQA security linter


### PR DESCRIPTION
Fixes a Tox configuration error (active since Tox v4) and simplifies the `clean` target at the same time.

```shell
clean: failed with rm is not allowed, use allowlist_externals to allow it
```